### PR TITLE
Fix repodata URL in "fetch artifacts" comment

### DIFF
--- a/bioconda_recipes_issue_responder/lib/main.js
+++ b/bioconda_recipes_issue_responder/lib/main.js
@@ -115,16 +115,16 @@ function makeArtifactComment(PR, sha) {
             var installOSX = "";
             // Table of packages and repodata.json
             artifacts.forEach(function (itemNever, idx, arr) {
-                var item = itemNever;
-                if (item.endsWith(".tar.bz2")) {
-                    let [, basedir = "", subdir = "", packageName = ""] = item.match(/^(.+)\/(.+)\/(.+)$/) || [];
+                let packageMatch = itemNever.match(/^(.+)\/(.+)\/(.+\.tar\.bz2)$/);
+                if (packageMatch) {
+                    let [url, basedir, subdir, packageName] = packageMatch;
                     let repoURL = [basedir, subdir, "repodata.json"].join("/");
                     let condaInstallURL = basedir;
-                    if (item.includes("/packages/noarch/")) {
+                    if (subdir === "noarch") {
                         comment += "noarch |";
                         installNoarch = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
                     }
-                    else if (item.includes("/packages/linux-64/")) {
+                    else if (subdir === "linux-64") {
                         comment += "linux-64 |";
                         installLinux = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
                     }
@@ -132,7 +132,7 @@ function makeArtifactComment(PR, sha) {
                         comment += "osx-64 |";
                         installOSX = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
                     }
-                    comment += " [" + packageName + "](" + item + ") | [repodata.json](" + repoURL + ")\n";
+                    comment += " [" + packageName + "](" + url + ") | [repodata.json](" + repoURL + ")\n";
                 }
             });
             // Conda install examples

--- a/bioconda_recipes_issue_responder/lib/main.js
+++ b/bioconda_recipes_issue_responder/lib/main.js
@@ -67,7 +67,8 @@ function fetchArtifacts(ID) {
         res = res.replace(/:pretty-path/g, "\"pretty-path\":");
         res = res.replace(/:url/g, "\"url\":");
         let artifacts = JSON.parse(res).filter(x => x['url'].endsWith(".tar.gz") || x['url'].endsWith(".tar.bz2") || x['url'].endsWith("/repodata.json")).map(x => x['url']);
-        return (artifacts);
+        let unique = (array) => [...new Set(array)];
+        return (unique(artifacts));
     });
 }
 // Given a PR and commit sha, fetch a list of the artifacts

--- a/bioconda_recipes_issue_responder/lib/main.js
+++ b/bioconda_recipes_issue_responder/lib/main.js
@@ -117,9 +117,9 @@ function makeArtifactComment(PR, sha) {
             artifacts.forEach(function (itemNever, idx, arr) {
                 var item = itemNever;
                 if (item.endsWith(".tar.bz2")) {
-                    let packageName = item.split("/").pop();
-                    let repoURL = arr[idx - 1];
-                    let condaInstallURL = item.split("/packages/")[0] + "/packages";
+                    let [, basedir = "", subdir = "", packageName = ""] = item.match(/^(.+)\/(.+)\/(.+)$/) || [];
+                    let repoURL = [basedir, subdir, "repodata.json"].join("/");
+                    let condaInstallURL = basedir;
                     if (item.includes("/packages/noarch/")) {
                         comment += "noarch |";
                         installNoarch = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";

--- a/bioconda_recipes_issue_responder/src/main.ts
+++ b/bioconda_recipes_issue_responder/src/main.ts
@@ -65,7 +65,8 @@ async function fetchArtifacts(ID) {
   res = res.replace(/:pretty-path/g, "\"pretty-path\":");
   res = res.replace(/:url/g, "\"url\":");
   let artifacts = JSON.parse(res).filter(x => x['url'].endsWith(".tar.gz") || x['url'].endsWith(".tar.bz2") || x['url'].endsWith("/repodata.json")).map(x => x['url']);
-  return(artifacts);
+  let unique = (array) => [...new Set(array)];
+  return(unique(artifacts));
 }
 
 

--- a/bioconda_recipes_issue_responder/src/main.ts
+++ b/bioconda_recipes_issue_responder/src/main.ts
@@ -116,23 +116,23 @@ async function makeArtifactComment(PR, sha) {
 
     // Table of packages and repodata.json
     artifacts.forEach(function(itemNever, idx, arr) {
-      var item = <string> itemNever;
-      if(item.endsWith(".tar.bz2")) {
-        let [, basedir = "", subdir = "", packageName = ""] = item.match(/^(.+)\/(.+)\/(.+)$/) || [];
+      let packageMatch = (<string> itemNever).match(/^(.+)\/(.+)\/(.+\.tar\.bz2)$/);
+      if(packageMatch) {
+        let [url, basedir, subdir, packageName] = packageMatch
         let repoURL = [basedir, subdir, "repodata.json"].join("/");
         let condaInstallURL = basedir;
 
-        if(item.includes("/packages/noarch/")) {
+        if(subdir === "noarch") {
           comment += "noarch |";
           installNoarch = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
-        } else if(item.includes("/packages/linux-64/")) {
+        } else if(subdir === "linux-64") {
           comment += "linux-64 |";
           installLinux = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
         } else {
           comment += "osx-64 |";
           installOSX = "```\nconda install -c " + condaInstallURL + " <package name>\n```\n";
         }
-        comment += " [" + packageName + "](" + item + ") | [repodata.json](" + repoURL + ")\n";
+        comment += " [" + packageName + "](" + url + ") | [repodata.json](" + repoURL + ")\n";
       }
     });
 

--- a/bioconda_recipes_issue_responder/src/main.ts
+++ b/bioconda_recipes_issue_responder/src/main.ts
@@ -118,9 +118,9 @@ async function makeArtifactComment(PR, sha) {
     artifacts.forEach(function(itemNever, idx, arr) {
       var item = <string> itemNever;
       if(item.endsWith(".tar.bz2")) {
-        let packageName = item.split("/").pop();
-        let repoURL = arr[idx - 1];
-        let condaInstallURL = item.split("/packages/")[0] + "/packages";
+        let [, basedir = "", subdir = "", packageName = ""] = item.match(/^(.+)\/(.+)\/(.+)$/) || [];
+        let repoURL = [basedir, subdir, "repodata.json"].join("/");
+        let condaInstallURL = basedir;
 
         if(item.includes("/packages/noarch/")) {
           comment += "noarch |";


### PR DESCRIPTION
In https://github.com/bioconda/bioconda-recipes/pull/19578#issuecomment-573202807 I noticed that the repodata URL is not always correct:

> Arch | Package | Repodata
-----|---------|---------
linux-64 | [gimmemotifs-0.14.1-py36h516909a_1.tar.bz2](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/linux-64/gimmemotifs-0.14.1-py36h516909a_1.tar.bz2) | [repodata.json](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/images/gimmemotifs%3A0.14.1--py36h516909a_1.tar.gz)
linux-64 | [gimmemotifs-0.14.1-py36h516909a_1.tar.bz2](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/linux-64/gimmemotifs-0.14.1-py36h516909a_1.tar.bz2) | [repodata.json](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/osx-64/repodata.json)
osx-64 | [gimmemotifs-0.14.1-py36h01d97ff_1.tar.bz2](https://89762-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/osx-64/gimmemotifs-0.14.1-py36h01d97ff_1.tar.bz2) | [repodata.json](https://89762-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/noarch/repodata.json)
***

```
Arch | Package | Repodata
-----|---------|---------
linux-64 | [gimmemotifs-0.14.1-py36h516909a_1.tar.bz2](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/linux-64/gimmemotifs-0.14.1-py36h516909a_1.tar.bz2) | [repodata.json](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/images/gimmemotifs%3A0.14.1--py36h516909a_1.tar.gz)
linux-64 | [gimmemotifs-0.14.1-py36h516909a_1.tar.bz2](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/linux-64/gimmemotifs-0.14.1-py36h516909a_1.tar.bz2) | [repodata.json](https://89725-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/osx-64/repodata.json)
osx-64 | [gimmemotifs-0.14.1-py36h01d97ff_1.tar.bz2](https://89762-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/osx-64/gimmemotifs-0.14.1-py36h01d97ff_1.tar.bz2) | [repodata.json](https://89762-42372094-gh.circle-artifacts.com/0/tmp/artifacts/packages/noarch/repodata.json)
***
```
which mean `let repoURL = arr[idx - 1];` does not seem to hold in all cases.
But the package should always lie in the same directory as the `repodata.json`, so we should be fine to use that then.

My "TypeScript-fu" is pretty much non-existent, but I believe this might work.